### PR TITLE
Add reproducible build badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Liftwizard
 
+[![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-green?labelColor=blue)](https://github.com/jvm-repo-rebuild/reproducible-central#io.liftwizard:liftwizard)
+
 Liftwizard is a collection of bundles and add-ons for [Dropwizard](https://www.dropwizard.io/), the Java framework for writing web services.
 
 There are very few dependencies between the bundles, so you can pick and choose the ones you want.


### PR DESCRIPTION
Adds a badge for `liftwizard` in the [Reproducible Central](https://github.com/jvm-repo-rebuild/reproducible-central) project.

liftwizard 0.1.0 has been verified as reproducible.
0.2.0 to 0.6.0 are being added now: https://github.com/jvm-repo-rebuild/reproducible-central/pull/36
