### PR TITLE
Disable Openrewrite rules that sometimes break code, or where the replacement isn't a stylistic improvement.

### DIFF
--- a/liftwizard-maven-build/liftwizard-parent-build/pom.xml
+++ b/liftwizard-maven-build/liftwizard-parent-build/pom.xml
@@ -577,7 +577,7 @@
                                     <recipe>org.openrewrite.java.testing.assertj.Assertj</recipe>
                                     <recipe>org.openrewrite.java.testing.junit5.JUnit5BestPractices</recipe>
 
-                                    <recipe>org.openrewrite.java.migrate.UpgradeToJava17</recipe>
+                                    <recipe>io.liftwizard.java.migrate.UpgradeToJava17</recipe>
                                 </activeRecipes>
                             </configuration>
                         </plugin>

--- a/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/common-static-analysis.yml
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/common-static-analysis.yml
@@ -33,7 +33,8 @@ recipeList:
   - org.openrewrite.staticanalysis.BooleanChecksNotInverted
   - org.openrewrite.staticanalysis.CaseInsensitiveComparisonsDoNotChangeCase
   - org.openrewrite.staticanalysis.CatchClauseOnlyRethrows
-  - org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
+# Disabled in Liftwizard
+#  - org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
   - org.openrewrite.staticanalysis.CovariantEquals
   - org.openrewrite.staticanalysis.DefaultComesLast
   - org.openrewrite.staticanalysis.EmptyBlock
@@ -44,7 +45,8 @@ recipeList:
   - org.openrewrite.staticanalysis.FinalizePrivateFields
   - org.openrewrite.staticanalysis.FallThrough
   - org.openrewrite.staticanalysis.FinalClass
-  - org.openrewrite.staticanalysis.FixStringFormatExpressions
+# Disabled in Liftwizard
+#  - org.openrewrite.staticanalysis.FixStringFormatExpressions
   - org.openrewrite.staticanalysis.ForLoopIncrementInUpdate
 #  - org.openrewrite.staticanalysis.HideUtilityClassConstructor
   - org.openrewrite.staticanalysis.IndexOfChecksShouldUseAStartPosition
@@ -85,7 +87,8 @@ recipeList:
 #  - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
   - org.openrewrite.staticanalysis.ReplaceStringBuilderWithString
   - org.openrewrite.staticanalysis.SimplifyBooleanExpression
-  - org.openrewrite.staticanalysis.SimplifyBooleanReturn
+# Disabled in Liftwizard
+#  - org.openrewrite.staticanalysis.SimplifyBooleanReturn
 #  - org.openrewrite.staticanalysis.SimplifyTernaryRecipes
   - org.openrewrite.staticanalysis.StaticMethodNotFinal
 # Disabled in Liftwizard

--- a/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/common-static-analysis.yml
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/common-static-analysis.yml
@@ -81,7 +81,8 @@ recipeList:
   - org.openrewrite.staticanalysis.RenameLocalVariablesToCamelCase
   - org.openrewrite.staticanalysis.RenameMethodsNamedHashcodeEqualOrTostring
   - org.openrewrite.staticanalysis.RenamePrivateFieldsToCamelCase
-  - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
+# Disabled in Liftwizard
+#  - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
   - org.openrewrite.staticanalysis.ReplaceStringBuilderWithString
   - org.openrewrite.staticanalysis.SimplifyBooleanExpression
   - org.openrewrite.staticanalysis.SimplifyBooleanReturn

--- a/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/java-version-17.yml
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/java-version-17.yml
@@ -1,0 +1,206 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.liftwizard.java.migrate.UpgradeToJava17
+displayName: Migrate to Java 17
+description: >
+  This recipe will apply changes commonly needed when migrating to Java 17. Specifically, for those
+  applications that are built on Java 8, this recipe will update and add dependencies on J2EE libraries that are no
+  longer directly bundled with the JDK. This recipe will also replace deprecated API with equivalents when there is a
+  clear migration strategy. Build files will also be updated to use Java 17 as the target/source and plugins will be
+  also be upgraded to versions that are compatible with Java 17.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.migrate.Java8toJava11
+  - org.openrewrite.java.migrate.JavaVersion17
+# Disabled in Liftwizard
+#  - org.openrewrite.java.migrate.lang.StringFormatted
+  - org.openrewrite.github.SetupJavaUpgradeJavaVersion:
+      minimumJavaMajorVersion: 17
+  - org.openrewrite.staticanalysis.InstanceOfPatternMatch
+  - org.openrewrite.java.migrate.RemoveMethodInvocation:
+      methodPattern: java.lang.Runtime traceInstructions(boolean)
+  - org.openrewrite.java.migrate.RemoveMethodInvocation:
+      methodPattern: java.lang.System traceMethodCalls(boolean)
+# Disabled in Liftwizard
+#  - org.openrewrite.java.migrate.lang.UseTextBlocks
+  - org.openrewrite.java.migrate.DeprecatedJavaxSecurityCert
+  - org.openrewrite.java.migrate.DeprecatedLogRecordThreadID
+  - org.openrewrite.java.migrate.RemovedLegacySunJSSEProviderName
+  - org.openrewrite.java.migrate.Jre17AgentMainPreMainPublic
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-checkstyle-plugin
+      newVersion: 3.x
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: com.sonatype.clm
+      artifactId: clm-maven-plugin
+      newVersion: 2.47.6-01
+  - org.openrewrite.java.migrate.RemovedZipFinalizeMethods
+  - org.openrewrite.java.migrate.RemovedSSLSessionGetPeerCertificateChainMethodImpl
+  - org.openrewrite.java.migrate.SunNetSslPackageUnavailable
+  - org.openrewrite.java.migrate.RemovedRMIConnectorServerCredentialTypesConstant
+  - org.openrewrite.java.migrate.RemovedFileIOFinalizeMethods
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.JavaVersion17
+displayName: Change Maven Java version property values to 17
+description: Change maven.compiler.source and maven.compiler.target values to 17.
+tags:
+  - java17
+  - compiler
+recipeList:
+  - org.openrewrite.java.migrate.UpgradeJavaVersion:
+      version: 17
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.DeprecatedJavaxSecurityCert
+displayName: Use `java.security.cert` instead of `javax.security.cert`
+description: The `javax.security.cert` package has been deprecated for removal.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: javax.security.cert
+      newPackageName: java.security.cert
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemovedLegacySunJSSEProviderName
+displayName: Use `SunJSSE` instead of `com.sun.net.ssl.internal.ssl.Provider`
+description: The `com.sun.net.ssl.internal.ssl.Provider` provider name was removed.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.migrate.ReplaceStringLiteralValue:
+      oldLiteralValue: com.sun.net.ssl.internal.ssl.Provider
+      newLiteralValue: SunJSSE
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.DeprecatedLogRecordThreadID
+displayName: Adopt `setLongThreadID` in `java.util.logging.LogRecord`
+description: Avoid using the deprecated methods in `java.util.logging.LogRecord`
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.util.logging.LogRecord getThreadID()
+      newMethodName: getLongThreadID
+  - org.openrewrite.java.migrate.ChangeMethodInvocationReturnType:
+      methodPattern: java.util.logging.LogRecord getLongThreadID()
+      newReturnType: long
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.util.logging.LogRecord setThreadID(int)
+      newMethodName: setLongThreadID
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.Jre17AgentMainPreMainPublic
+displayName: Set visibility of `premain` and `agentmain` methods to `public`
+description: Check for a behavior change in Java agents.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.ChangeMethodAccessLevel:
+      methodPattern: "*..* agentmain(java.lang.String)"
+      newAccessLevel: public
+  - org.openrewrite.java.ChangeMethodAccessLevel:
+      methodPattern: "*..* agentmain(java.lang.String, java.lang.instrument.Instrumentation)"
+      newAccessLevel: public
+  - org.openrewrite.java.ChangeMethodAccessLevel:
+      methodPattern: "*..* premain(java.lang.String)"
+      newAccessLevel: public
+  - org.openrewrite.java.ChangeMethodAccessLevel:
+      methodPattern: "*..* premain(java.lang.String, java.lang.instrument.Instrumentation)"
+      newAccessLevel: public
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemovedZipFinalizeMethods
+displayName: Replace `finalize` method in `java.util.zip.Zipfile`, `java.util.zip.Inflater` and `java.util.zip.Deflater`
+description: >
+  The `finalize` method in `java.util.zip.ZipFile` is replaced with the `close` method and is replaced by the `end` method in 
+   `java.util.zip.Inflater` and `java.util.zip.Deflater` as it is no longer available in Java SE 12 and later.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "java.util.zip.Inflater finalize()"
+      newMethodName: end
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "java.util.zip.Deflater finalize()"
+      newMethodName: end
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "java.util.zip.ZipFile finalize()"
+      newMethodName: close
+      ignoreDefinition: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemovedSSLSessionGetPeerCertificateChainMethodImpl
+displayName: Replace `SSLSession.getPeerCertificateChain()` method
+description: >
+  The `javax.net.ssl.SSLSession.getPeerCertificateChain()` method implementation was removed from the SunJSSE provider and HTTP client implementation in Java SE 15. 
+  The default implementation will now throw an `UnsupportedOperationException`. 
+  Applications using this method should be updated to use the `javax.net.ssl.SSLSession.getPeerCertificates()` method instead.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "javax.net.ssl.SSLSession getPeerCertificateChain()"
+      newMethodName: getPeerCertificates
+      ignoreDefinition: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.SunNetSslPackageUnavailable
+displayName: Replace `com.sun.net.ssl` package
+description: >
+  The internal API `com.sun.net.ssl` is removed. The package was intended for internal use only and replacement APIs can be found in the `javax.net.ssl` package.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: com.sun.net.ssl
+      newPackageName: javax.net.ssl
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemovedRMIConnectorServerCredentialTypesConstant
+displayName: Replace `RMIConnectorServer.CREDENTIAL_TYPES` constant
+description: >
+  This recipe replaces the `RMIConnectorServer.CREDENTIAL_TYPES` constant with the `RMIConnectorServer.CREDENTIALS_FILTER_PATTERN` constant.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: javax.management.remote.rmi.RMIConnectorServer.CREDENTIAL_TYPES
+      fullyQualifiedConstantName:  javax.management.remote.rmi.RMIConnectorServer.CREDENTIALS_FILTER_PATTERN
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.migrate.RemovedFileIOFinalizeMethods
+displayName: Replace `finalize` method in `java.io.FileInputStream`  and `java.io.FileOutputStream`
+description: >
+  The `finalize` method in `java.io.FileInputStream` and `java.io.FileOutputStream` is no longer available in Java SE 12 and later. The recipe replaces it with the `close` method.
+tags:
+  - java17
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "java.io.FileInputStream finalize()"
+      newMethodName: close
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "java.io.FileOutputStream finalize()"
+      newMethodName: close
+      ignoreDefinition: true


### PR DESCRIPTION
Disable Openrewrite rules where the replacement is not always a stylistic improvement:
    
 - ChainStringBuilderAppendCalls
 - SimplifyBooleanReturn
 - FixStringFormatExpressions
 - StringFormatted
 - StringFormatted
 - UseTextBlocks

Disable Openrewrite rules that sometimes break code:

 - ReplaceLambdaWithMethodReference, which sometimes breaks code.