### PR TITLE
Reimlement LogstashEncoderFactory without delegating to LogstashEncoder.

### DIFF
--- a/liftwizard-logging/liftwizard-config-logging-logstash-console/src/main/java/io/liftwizard/dropwizard/configuration/logging/appender/console/logstash/LogstashAccessConsoleAppenderFactory.java
+++ b/liftwizard-logging/liftwizard-config-logging-logstash-console/src/main/java/io/liftwizard/dropwizard/configuration/logging/appender/console/logstash/LogstashAccessConsoleAppenderFactory.java
@@ -78,7 +78,7 @@ public class LogstashAccessConsoleAppenderFactory
             LevelFilterFactory<IAccessEvent> levelFilterFactory,
             AsyncAppenderFactory<IAccessEvent> asyncAppenderFactory)
     {
-        Encoder<IAccessEvent>              encoder  = this.encoderFactory.build();
+        Encoder<IAccessEvent>              encoder  = this.encoderFactory.build(this.getTimeZone());
         OutputStreamAppender<IAccessEvent> appender = this.appender(context);
         appender.setEncoder(encoder);
         encoder.start();

--- a/liftwizard-logging/liftwizard-config-logging-logstash-console/src/main/java/io/liftwizard/dropwizard/configuration/logging/appender/console/logstash/LogstashConsoleAppenderFactory.java
+++ b/liftwizard-logging/liftwizard-config-logging-logstash-console/src/main/java/io/liftwizard/dropwizard/configuration/logging/appender/console/logstash/LogstashConsoleAppenderFactory.java
@@ -78,7 +78,7 @@ public class LogstashConsoleAppenderFactory
             LevelFilterFactory<ILoggingEvent> levelFilterFactory,
             AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory)
     {
-        Encoder<ILoggingEvent>              encoder  = this.encoderFactory.build(this.isIncludeCallerData());
+        Encoder<ILoggingEvent>              encoder  = this.encoderFactory.build(this.isIncludeCallerData(), this.getTimeZone());
         OutputStreamAppender<ILoggingEvent> appender = this.appender(context);
         appender.setEncoder(encoder);
         encoder.start();

--- a/liftwizard-logging/liftwizard-config-logging-logstash-encoder/src/main/java/io/liftwizard/dropwizard/configuration/logging/logstash/LogstashAccessEncoderFactory.java
+++ b/liftwizard-logging/liftwizard-config-logging-logstash-encoder/src/main/java/io/liftwizard/dropwizard/configuration/logging/logstash/LogstashAccessEncoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Craig Motlin
+ * Copyright 2024 Craig Motlin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,25 @@
 
 package io.liftwizard.dropwizard.configuration.logging.logstash;
 
+import java.util.TimeZone;
+
 import javax.validation.constraints.NotNull;
 
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.encoder.Encoder;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import net.logstash.logback.composite.GlobalCustomFieldsJsonProvider;
 import net.logstash.logback.decorate.JsonFactoryDecorator;
 import net.logstash.logback.encoder.LogstashAccessEncoder;
 
 public class LogstashAccessEncoderFactory
 {
-    private          boolean includeContext         = true;
-    private          boolean prettyPrint;
-    private @NotNull Include serializationInclusion = Include.NON_ABSENT;
+    private          boolean    includeContext         = true;
+    private          ObjectNode customFields;
+    private          boolean    prettyPrint;
+    private @NotNull Include    serializationInclusion = Include.NON_ABSENT;
 
     @JsonProperty
     public boolean isIncludeContext()
@@ -41,6 +46,18 @@ public class LogstashAccessEncoderFactory
     public void setIncludeContext(boolean includeContext)
     {
         this.includeContext = includeContext;
+    }
+
+    @JsonProperty
+    public ObjectNode getCustomFields()
+    {
+        return this.customFields;
+    }
+
+    @JsonProperty
+    public void setCustomFields(ObjectNode customFields)
+    {
+        this.customFields = customFields;
     }
 
     @JsonProperty
@@ -67,10 +84,19 @@ public class LogstashAccessEncoderFactory
         this.serializationInclusion = serializationInclusion;
     }
 
-    public Encoder<IAccessEvent> build()
+    public Encoder<IAccessEvent> build(TimeZone timeZone)
     {
         LogstashAccessEncoder encoder = new LogstashAccessEncoder();
         encoder.setIncludeContext(this.includeContext);
+
+        if (this.customFields != null && !this.customFields.isEmpty())
+        {
+            GlobalCustomFieldsJsonProvider<IAccessEvent> globalCustomFieldsProvider = new GlobalCustomFieldsJsonProvider<>();
+            globalCustomFieldsProvider.setCustomFieldsNode(this.customFields);
+            encoder.getProviders().addProvider(globalCustomFieldsProvider);
+        }
+
+        encoder.setTimeZone(timeZone.getID());
         if (this.prettyPrint)
         {
             encoder.setJsonGeneratorDecorator(new PrettyPrintingJsonGeneratorDecorator());

--- a/liftwizard-logging/liftwizard-config-logging-logstash-encoder/src/main/java/io/liftwizard/dropwizard/configuration/logging/logstash/LogstashEncoderFactory.java
+++ b/liftwizard-logging/liftwizard-config-logging-logstash-encoder/src/main/java/io/liftwizard/dropwizard/configuration/logging/logstash/LogstashEncoderFactory.java
@@ -16,25 +16,56 @@
 
 package io.liftwizard.dropwizard.configuration.logging.logstash;
 
+import java.util.List;
+import java.util.TimeZone;
+
 import javax.validation.constraints.NotNull;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.encoder.Encoder;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import net.logstash.logback.composite.ContextJsonProvider;
+import net.logstash.logback.composite.GlobalCustomFieldsJsonProvider;
+import net.logstash.logback.composite.JsonProvider;
+import net.logstash.logback.composite.JsonProviders;
+import net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider;
+import net.logstash.logback.composite.loggingevent.CallerDataJsonProvider;
+import net.logstash.logback.composite.loggingevent.LogLevelJsonProvider;
+import net.logstash.logback.composite.loggingevent.LoggerNameJsonProvider;
+import net.logstash.logback.composite.loggingevent.LoggingEventFormattedTimestampJsonProvider;
+import net.logstash.logback.composite.loggingevent.LoggingEventNestedJsonProvider;
+import net.logstash.logback.composite.loggingevent.LoggingEventThreadNameJsonProvider;
+import net.logstash.logback.composite.loggingevent.LogstashMarkersJsonProvider;
+import net.logstash.logback.composite.loggingevent.MdcJsonProvider;
+import net.logstash.logback.composite.loggingevent.MessageJsonProvider;
+import net.logstash.logback.composite.loggingevent.RootStackTraceElementJsonProvider;
+import net.logstash.logback.composite.loggingevent.StackHashJsonProvider;
+import net.logstash.logback.composite.loggingevent.StackTraceJsonProvider;
+import net.logstash.logback.composite.loggingevent.TagsJsonProvider;
+import net.logstash.logback.composite.loggingevent.ThrowableClassNameJsonProvider;
+import net.logstash.logback.composite.loggingevent.ThrowableMessageJsonProvider;
+import net.logstash.logback.composite.loggingevent.ThrowableRootCauseClassNameJsonProvider;
+import net.logstash.logback.composite.loggingevent.ThrowableRootCauseMessageJsonProvider;
 import net.logstash.logback.decorate.JsonFactoryDecorator;
-import net.logstash.logback.encoder.LogstashEncoder;
+import net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder;
+import net.logstash.logback.stacktrace.ShortenedThrowableConverter;
 
 public class LogstashEncoderFactory
 {
-    private          boolean includeContext             = true;
-    private          boolean includeMdc                 = true;
-    private          boolean includeStructuredArguments = true;
-    private          boolean includedNonStructuredArguments;
-    private          boolean includeTags                = true;
-    private          String  customFields;
-    private          boolean prettyPrint;
-    private @NotNull Include serializationInclusion     = Include.NON_ABSENT;
+    private          boolean      includeContext                   = true;
+    private          boolean      includeMdc                       = true;
+    private          boolean      includeStructuredArguments       = true;
+    private          boolean      includedNonStructuredArguments;
+    private          boolean      includeTags                      = true;
+    private          boolean      rootCauseFirst                   = true;
+    private          List<String> truncateStackTracesAfterPrefixes = List.of(
+            "^org\\.junit\\.platform\\.engine",
+            "^org\\.junit\\.jupiter\\.engine");
+    private          ObjectNode   customFields;
+    private          boolean      prettyPrint;
+    private @NotNull Include      serializationInclusion           = Include.NON_ABSENT;
 
     @JsonProperty
     public boolean isIncludeContext()
@@ -97,15 +128,39 @@ public class LogstashEncoderFactory
     }
 
     @JsonProperty
-    public String getCustomFields()
+    public ObjectNode getCustomFields()
     {
         return this.customFields;
     }
 
     @JsonProperty
-    public void setCustomFields(String customFields)
+    public void setCustomFields(ObjectNode customFields)
     {
         this.customFields = customFields;
+    }
+
+    @JsonProperty
+    public boolean isRootCauseFirst()
+    {
+        return this.rootCauseFirst;
+    }
+
+    @JsonProperty
+    public void setRootCauseFirst(boolean rootCauseFirst)
+    {
+        this.rootCauseFirst = rootCauseFirst;
+    }
+
+    @JsonProperty
+    public List<String> getTruncateStackTracesAfterPrefixes()
+    {
+        return this.truncateStackTracesAfterPrefixes;
+    }
+
+    @JsonProperty
+    public void setTruncateStackTracesAfterPrefixes(List<String> truncateStackTracesAfterPrefixes)
+    {
+        this.truncateStackTracesAfterPrefixes = truncateStackTracesAfterPrefixes;
     }
 
     @JsonProperty
@@ -132,24 +187,173 @@ public class LogstashEncoderFactory
         this.serializationInclusion = serializationInclusion;
     }
 
-    public Encoder<ILoggingEvent> build(boolean includeCallerData)
+    public Encoder<ILoggingEvent> build(boolean includeCallerData, TimeZone timeZone)
     {
-        LogstashEncoder encoder = new LogstashEncoder();
-        encoder.setIncludeCallerData(includeCallerData);
-        encoder.setIncludeContext(this.includeContext);
-        encoder.setIncludeMdc(this.includeMdc);
-        encoder.setIncludeStructuredArguments(this.includeStructuredArguments);
-        encoder.setIncludeNonStructuredArguments(this.includedNonStructuredArguments);
-        encoder.setIncludeTags(this.includeTags);
-        encoder.setCustomFields(this.customFields);
+        var encoder = new LoggingEventCompositeJsonEncoder();
+
+        JsonProviders<ILoggingEvent> providers = this.getProviders(includeCallerData, timeZone);
+        encoder.setProviders(providers);
+
         if (this.prettyPrint)
         {
             encoder.setJsonGeneratorDecorator(new PrettyPrintingJsonGeneratorDecorator());
         }
+
         JsonFactoryDecorator decorator = new ObjectMapperConfigJsonFactoryDecorator(
                 this.prettyPrint,
                 this.serializationInclusion);
         encoder.setJsonFactoryDecorator(decorator);
+
         return encoder;
+    }
+
+    private JsonProviders<ILoggingEvent> getProviders(
+            boolean includeCallerData,
+            TimeZone timeZone)
+    {
+        JsonProviders<ILoggingEvent> providers = new JsonProviders<>();
+
+        providers.addProvider(getTimestampProvider(timeZone));
+        providers.addProvider(new MessageJsonProvider());
+        providers.addProvider(new LoggerNameJsonProvider());
+        providers.addProvider(new LoggingEventThreadNameJsonProvider());
+        providers.addProvider(new LogLevelJsonProvider());
+
+        if (includeCallerData)
+        {
+            providers.addProvider(nest("caller", getCallerDataProvider()));
+        }
+
+        if (this.includeContext)
+        {
+            providers.addProvider(new ContextJsonProvider<>());
+        }
+
+        if (this.includeMdc)
+        {
+            providers.addProvider(nest("mdc", new MdcJsonProvider()));
+        }
+
+        providers.addProvider(nest("arguments", this.getArgumentsJsonProvider()));
+
+        if (this.includeTags)
+        {
+            providers.addProvider(new TagsJsonProvider());
+        }
+
+        providers.addProvider(new LogstashMarkersJsonProvider());
+
+        if (this.customFields != null && !this.customFields.isEmpty())
+        {
+            providers.addProvider(this.getGlobalCustomFieldsProvider());
+        }
+
+        providers.addProvider(nest("error", this.getErrorProvider()));
+        return providers;
+    }
+
+    private static LoggingEventFormattedTimestampJsonProvider getTimestampProvider(TimeZone timeZone)
+    {
+        var provider = new LoggingEventFormattedTimestampJsonProvider();
+        provider.setTimeZone(timeZone.getID());
+        return provider;
+    }
+
+    private static CallerDataJsonProvider getCallerDataProvider()
+    {
+        var provider = new CallerDataJsonProvider();
+        provider.setClassFieldName("class_name");
+        provider.setMethodFieldName("method_name");
+        provider.setFileFieldName("file_name");
+        provider.setLineFieldName("line_number");
+        return provider;
+    }
+
+    private GlobalCustomFieldsJsonProvider<ILoggingEvent> getGlobalCustomFieldsProvider()
+    {
+        var provider = new GlobalCustomFieldsJsonProvider<ILoggingEvent>();
+        provider.setCustomFieldsNode(this.customFields);
+        return provider;
+    }
+
+    private JsonProviders<ILoggingEvent> getErrorProvider()
+    {
+        JsonProviders<ILoggingEvent> providers = new JsonProviders<>();
+        providers.addProvider(this.getStackTraceProvider());
+        providers.addProvider(getThrowableClassNameProvider());
+        providers.addProvider(getThrowableRootCauseClassNameJson());
+        providers.addProvider(new ThrowableMessageJsonProvider());
+        providers.addProvider(new ThrowableRootCauseMessageJsonProvider());
+        providers.addProvider(new StackHashJsonProvider());
+        providers.addProvider(new RootStackTraceElementJsonProvider());
+
+        return providers;
+    }
+
+    private StackTraceJsonProvider getStackTraceProvider()
+    {
+        var provider = new StackTraceJsonProvider();
+        provider.setThrowableConverter(this.getThrowableConverter());
+        return provider;
+    }
+
+    private static ThrowableClassNameJsonProvider getThrowableClassNameProvider()
+    {
+        var provider = new ThrowableClassNameJsonProvider();
+        provider.setUseSimpleClassName(false);
+        return provider;
+    }
+
+    private static ThrowableRootCauseClassNameJsonProvider getThrowableRootCauseClassNameJson()
+    {
+        var provider = new ThrowableRootCauseClassNameJsonProvider();
+        provider.setUseSimpleClassName(false);
+        return provider;
+    }
+
+    private ShortenedThrowableConverter getThrowableConverter()
+    {
+        var throwableConverter = new ShortenedThrowableConverter();
+        if (this.rootCauseFirst)
+        {
+            throwableConverter.setRootCauseFirst(true);
+        }
+        this.truncateStackTracesAfterPrefixes.forEach(throwableConverter::addTruncateAfter);
+        return throwableConverter;
+    }
+
+    private ArgumentsJsonProvider getArgumentsJsonProvider()
+    {
+        var provider = new ArgumentsJsonProvider();
+        provider.setIncludeStructuredArguments(this.includeStructuredArguments);
+        provider.setIncludeNonStructuredArguments(this.includedNonStructuredArguments);
+        return provider;
+    }
+
+    private static LoggingEventNestedJsonProvider nest(
+            String fieldName,
+            JsonProvider<ILoggingEvent> delegateProvider)
+    {
+        var provider = new LoggingEventNestedJsonProvider();
+        provider.setFieldName(fieldName);
+        provider.setProviders(wrap(delegateProvider));
+        return provider;
+    }
+
+    private static LoggingEventNestedJsonProvider nest(
+            String fieldName,
+            JsonProviders<ILoggingEvent> jsonProviders)
+    {
+        var provider = new LoggingEventNestedJsonProvider();
+        provider.setFieldName(fieldName);
+        provider.setProviders(jsonProviders);
+        return provider;
+    }
+
+    private static JsonProviders<ILoggingEvent> wrap(JsonProvider<ILoggingEvent> delegateProvider)
+    {
+        JsonProviders<ILoggingEvent> providers = new JsonProviders<>();
+        providers.addProvider(delegateProvider);
+        return providers;
     }
 }

--- a/liftwizard-logging/liftwizard-config-logging-logstash-file/src/main/java/io/liftwizard/dropwizard/configuration/logging/appender/file/logstash/LogstashAccessFileAppenderFactory.java
+++ b/liftwizard-logging/liftwizard-config-logging-logstash-file/src/main/java/io/liftwizard/dropwizard/configuration/logging/appender/file/logstash/LogstashAccessFileAppenderFactory.java
@@ -220,7 +220,7 @@ public class LogstashAccessFileAppenderFactory
             LevelFilterFactory<IAccessEvent> levelFilterFactory,
             AsyncAppenderFactory<IAccessEvent> asyncAppenderFactory)
     {
-        Encoder<IAccessEvent>              encoder  = this.encoderFactory.build();
+        Encoder<IAccessEvent>              encoder  = this.encoderFactory.build(this.getTimeZone());
         OutputStreamAppender<IAccessEvent> appender = this.appender(context);
         appender.setEncoder(encoder);
         encoder.start();

--- a/liftwizard-logging/liftwizard-config-logging-logstash-file/src/main/java/io/liftwizard/dropwizard/configuration/logging/appender/file/logstash/LogstashFileAppenderFactory.java
+++ b/liftwizard-logging/liftwizard-config-logging-logstash-file/src/main/java/io/liftwizard/dropwizard/configuration/logging/appender/file/logstash/LogstashFileAppenderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Craig Motlin
+ * Copyright 2024 Craig Motlin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,7 +225,7 @@ public class LogstashFileAppenderFactory
             LevelFilterFactory<ILoggingEvent> levelFilterFactory,
             AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory)
     {
-        Encoder<ILoggingEvent>              encoder  = this.encoderFactory.build(this.isIncludeCallerData());
+        Encoder<ILoggingEvent>              encoder  = this.encoderFactory.build(this.isIncludeCallerData(), this.getTimeZone());
         OutputStreamAppender<ILoggingEvent> appender = this.appender(context);
         appender.setEncoder(encoder);
         encoder.start();


### PR DESCRIPTION
Stacked on top of #1985

Reimplements LogstashEncoderFactory from scratch, without delegating to LogstashEncoder. This adds and removes functionality.

- We can set the timezone for the `@timestamp`, including to the magic string `"system"`
- `customFields` is now an ObjectNode instead of a String, so custom fields no longer look like json-in-json
- custom fields can be added to access logs
- structured arguments are nested under `arguments`
- mdc arguments are nested under `mdc`
- caller information is nested under `caller`
- error information is added under `error` and a new config option is added to control whether exception cause chains are root-first or root-last
- version and level_value are no longer included

Example of a log with MDC:

```json
{
  "@timestamp": "2024-05-06T02:23:12.787Z",
  "message": "Running ConfigLoggingBundle.",
  "logger_name": "io.liftwizard.dropwizard.bundle.config.logging.ConfigLoggingBundle",
  "thread_name": "main",
  "level": "INFO",
  "caller": {
    "class_name": "io.liftwizard.dropwizard.bundle.config.logging.ConfigLoggingBundle",
    "method_name": "runWithMdc",
    "file_name": "ConfigLoggingBundle.java",
    "line_number": 66
  },
  "mdc": {
    "liftwizard.bundle": "ConfigLoggingBundle",
    "liftwizard.priority": "-9"
  },
  "arguments": {
    "arg0": "ConfigLoggingBundle"
  },
  "error": {}
}
```

Example of a log with an error:

```json
{
  "@timestamp": "2024-05-06T02:51:10.608Z",
  "message": "CoverageExampleApplication.run",
  "logger_name": "cool.klass.xample.coverage.dropwizard.application.CoverageExampleApplication",
  "thread_name": "main",
  "level": "ERROR",
  "caller": {
    "class_name": "cool.klass.xample.coverage.dropwizard.application.CoverageExampleApplication",
    "method_name": "run",
    "file_name": "CoverageExampleApplication.java",
    "line_number": 114
  },
  "mdc": {},
  "arguments": {},
  "error": {
    "stack_trace": "cool.klass.xample.coverage.dropwizard.application.CauseException: null\n\tat cool.klass.xample.coverage.dropwizard.application.CoverageExampleApplication.run(CoverageExampleApplication.java:112)\n\t... 62 common frames omitted\nWrapped by: cool.klass.xample.coverage.dropwizard.application.RootException: example message\n\tat cool.klass.xample.coverage.dropwizard.application.CoverageExampleApplication.run(CoverageExampleApplication.java:113)\n\tat cool.klass.xample.coverage.dropwizard.application.CoverageExampleApplication.run(CoverageExampleApplication.java:38)\n\tat io.dropwizard.cli.EnvironmentCommand.run(EnvironmentCommand.java:67)\n\tat io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:98)\n\tat io.dropwizard.testing.DropwizardTestSupport.startIfRequired(DropwizardTestSupport.java:326)\n\tat io.dropwizard.testing.DropwizardTestSupport.before(DropwizardTestSupport.java:226)\n\tat io.liftwizard.junit.extension.app.LiftwizardAppExtension.before(LiftwizardAppExtension.java:217)\n\tat io.dropwizard.testing.junit5.DropwizardExtensionsSupport.beforeEach(DropwizardExtensionsSupport.java:123)\n\tat io.dropwizard.testing.junit5.DropwizardExtensionsSupport.beforeEach(DropwizardExtensionsSupport.java:106)\n\tat org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeBeforeEachCallbacks$2(TestMethodTestDescriptor.java:167)\n\t... 53 frames truncated\n",
    "throwable_class": "cool.klass.xample.coverage.dropwizard.application.RootException",
    "throwable_root_cause_class": "cool.klass.xample.coverage.dropwizard.application.CauseException",
    "throwable_message": "example message",
    "stack_hash": "48972710",
    "root_stack_trace_element": {
      "class_name": "cool.klass.xample.coverage.dropwizard.application.CoverageExampleApplication",
      "method_name": "run"
    }
  }
}
```

An example of StructuredArgumentsLogstashEncoderLogger logging.

```json
{
  "@timestamp": "2024-05-06T02:51:11.681Z",
  "message": "Response sent",
  "logger_name": "io.liftwizard.servlet.logging.logstash.encoder.StructuredArgumentsLogstashEncoderLogger",
  "thread_name": "dw-76",
  "level": "DEBUG",
  "caller": {
    "class_name": "io.liftwizard.servlet.logging.logstash.encoder.StructuredArgumentsLogstashEncoderLogger",
    "method_name": "accept",
    "file_name": "StructuredArgumentsLogstashEncoderLogger.java",
    "line_number": 36
  },
  "mdc": {},
  "arguments": {},
  "request": {
    "http": {
      "headers": {
        "User-Agent": "CoverageExample (cool.klass.xample.coverage.dropwizard.test.PropertiesRequiredTest.getFirst)",
        "Host": "localhost:49544"
      },
      "method": "GET",
      "path": {
        "absolute": "http://localhost:49544/api/propertiesRequired/1",
        "full": "/api/propertiesRequired/1",
        "template": "/propertiesRequired/{propertiesRequiredId}/"
      },
      "parameters": {
        "query": {},
        "path": {
          "propertiesRequiredId": "1"
        }
      },
      "client": {
        "address": "127.0.0.1",
        "host": "127.0.0.1",
        "port": 49550
      },
      "server": {
        "scheme": "http",
        "name": "localhost",
        "port": 49544
      }
    },
    "resourceClass": "cool.klass.xample.coverage.service.resource.PropertiesRequiredResource",
    "resourceMethod": "method0"
  },
  "response": {
    "http": {
      "headers": {},
      "body": "{\n  \"propertiesRequiredId\" : 1,\n  \"systemFrom\" : \"1999-12-31T23:59:00Z\",\n  \"systemTo\" : null,\n  \"createdOn\" : \"1999-12-31T23:59:00Z\",\n  \"requiredString\" : \"PropertiesRequired requiredString 1 â\",\n  \"requiredInteger\" : 1,\n  \"requiredLong\" : 100000000000,\n  \"requiredDouble\" : 1.0123456789,\n  \"requiredFloat\" : 1.0123457,\n  \"requiredBoolean\" : true,\n  \"requiredInstant\" : \"1999-12-31T23:59:00Z\",\n  \"requiredLocalDate\" : \"1999-12-31\",\n  \"requiredDerived\" : \"cool.klass.xample.coverage.PropertiesRequired.getRequiredDerived\",\n  \"version\" : {\n    \"systemFrom\" : \"1999-12-31T23:59:00Z\",\n    \"systemTo\" : null,\n    \"createdOn\" : \"1999-12-31T23:59:00Z\",\n    \"number\" : 1,\n    \"createdBy\" : {\n      \"userId\" : \"User userId 1 â\",\n      \"systemFrom\" : \"1999-12-31T23:59:00Z\",\n      \"systemTo\" : null,\n      \"firstName\" : \"User firstName 1 â\",\n      \"lastName\" : \"User lastName 1 â\",\n      \"email\" : \"User email 1 â\"\n    },\n    \"lastUpdatedBy\" : {\n      \"userId\" : \"User userId 1 â\",\n      \"systemFrom\" : \"1999-12-31T23:59:0...more...",
      "contentLength": 1670,
      "status": {
        "status": "OK",
        "code": 200,
        "family": "SUCCESSFUL",
        "phrase": "OK"
      },
      "entityType": "cool.klass.xample.coverage.PropertiesRequired",
      "elapsedNanos": 86400000000000
    }
  },
  "error": {}
}
```
