### PR TITLE
Revert "Upgrade JsonPrettyPrinter to use the new built-in configuration options in Jackson 2.17."

### DIFF
--- a/liftwizard-jackson/liftwizard-jackson-pretty-printer/src/main/java/io/liftwizard/serialization/jackson/pretty/JsonLinesPrettyPrinter.java
+++ b/liftwizard-jackson/liftwizard-jackson-pretty-printer/src/main/java/io/liftwizard/serialization/jackson/pretty/JsonLinesPrettyPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Craig Motlin
+ * Copyright 2024 Craig Motlin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,32 @@
  * limitations under the License.
  */
 
-package io.liftwizard.dropwizard.configuration.logging.logstash;
+package io.liftwizard.serialization.jackson.pretty;
+
+import java.io.IOException;
 
 import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import io.liftwizard.serialization.jackson.pretty.JsonLinesPrettyPrinter;
-import net.logstash.logback.decorate.JsonGeneratorDecorator;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 
-public class PrettyPrintingJsonGeneratorDecorator
-        implements JsonGeneratorDecorator
+public class JsonLinesPrettyPrinter extends DefaultPrettyPrinter
 {
-    @Override
-    public JsonGenerator decorate(@Nonnull JsonGenerator generator)
+    public JsonLinesPrettyPrinter()
     {
-        generator.setPrettyPrinter(new JsonLinesPrettyPrinter());
-        generator.useDefaultPrettyPrinter();
-        return generator;
+        this._arrayIndenter = JsonPrettyPrinter.INDENTER;
+    }
+
+    @Nonnull
+    @Override
+    public DefaultPrettyPrinter createInstance()
+    {
+        return this;
+    }
+
+    @Override
+    public void writeObjectFieldValueSeparator(@Nonnull JsonGenerator jsonGenerator) throws IOException
+    {
+        jsonGenerator.writeRaw(this._separators.getObjectFieldValueSeparator() + " ");
     }
 }

--- a/liftwizard-jackson/liftwizard-jackson-pretty-printer/src/main/java/io/liftwizard/serialization/jackson/pretty/JsonPrettyPrinter.java
+++ b/liftwizard-jackson/liftwizard-jackson-pretty-printer/src/main/java/io/liftwizard/serialization/jackson/pretty/JsonPrettyPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Craig Motlin
+ * Copyright 2020 Craig Motlin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 
 package io.liftwizard.serialization.jackson.pretty;
 
+import java.io.IOException;
+
 import javax.annotation.Nonnull;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.Separators;
@@ -32,10 +35,8 @@ public class JsonPrettyPrinter
             Spacing.AFTER,
             ',',
             Spacing.NONE,
-            "",
             ',',
-            Spacing.NONE,
-            "");
+            Spacing.NONE);
 
     public static final DefaultIndenter INDENTER   = new DefaultIndenter("  ", "\n");
 
@@ -56,5 +57,43 @@ public class JsonPrettyPrinter
     public DefaultPrettyPrinter createInstance()
     {
         return this;
+    }
+
+    @Override
+    public void writeEndArray(JsonGenerator jsonGenerator, int nrOfValues)
+            throws IOException
+    {
+        if (!this._arrayIndenter.isInline())
+        {
+            --this._nesting;
+        }
+        if (nrOfValues > 0)
+        {
+            this._arrayIndenter.writeIndentation(jsonGenerator, this._nesting);
+        }
+        else
+        {
+            // jsonGenerator.writeRaw(' ');
+        }
+        jsonGenerator.writeRaw(']');
+    }
+
+    @Override
+    public void writeEndObject(JsonGenerator g, int nrOfEntries)
+            throws IOException
+    {
+        if (!this._objectIndenter.isInline())
+        {
+            --this._nesting;
+        }
+        if (nrOfEntries > 0)
+        {
+            this._objectIndenter.writeIndentation(g, this._nesting);
+        }
+        else
+        {
+            // g.writeRaw(' ');
+        }
+        g.writeRaw('}');
     }
 }


### PR DESCRIPTION


This reverts commit 09a73751cde9cdfa058c685c69320b60ed964878.